### PR TITLE
docs: add .env.example and .env.test.example templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,85 @@
+# OneRamp Frontend — Environment Variables
+#
+# Copy this file to .env.local and fill in the values:
+#   cp .env.example .env.local
+#
+# Variables prefixed with NEXT_PUBLIC_ are exposed to the browser bundle.
+# Never put secrets behind a NEXT_PUBLIC_ prefix.
+
+# ------------------------------------------------------------------
+# REQUIRED — the app will not function without these
+# ------------------------------------------------------------------
+
+# OneRamp backend API. Every tRPC/action call (rates, quotes, institutions,
+# KYC, transfers) hits this base URL with the bearer token below.
+# Used by: constants/index.ts
+ONERAMP_API_URL=https://your-oneramp-backend.example.com
+ONERAMP_API_KEY=your-oneramp-bearer-token
+
+# ------------------------------------------------------------------
+# WEB3 / WALLET — optional but strongly recommended
+# Missing these degrades wallet and on-chain functionality.
+# ------------------------------------------------------------------
+
+# Reown AppKit (WalletConnect) project ID — https://cloud.reown.com
+# Has a hardcoded fallback in src/config/index.tsx, but you should set
+# your own for production so analytics/limits are attributed correctly.
+REOWN_PROJECT_ID=
+
+# Coinbase Developer Platform client key — https://portal.cdp.coinbase.com
+# Required by the OnchainKit / MiniKit provider for Coinbase Smart Wallet.
+# Used by: src/app/providers/minikit-provider.tsx
+NEXT_PUBLIC_CDP_CLIENT_API_KEY=
+
+# Infura API key for Base mainnet RPC — https://infura.io
+# Used for token balance lookups, Aerodrome swap quotes, and v3 rate fetching.
+# Falls back to the public Base RPC if unset (lower rate limits).
+# Used by: src/utils/v3-rate-fetcher.ts, src/hooks/useTokenBalance.tsx,
+#          src/hooks/useAerodromeSwap.tsx
+NEXT_PUBLIC_INFURA_API_KEY=
+
+# ------------------------------------------------------------------
+# FARCASTER MINI APP MANIFEST — optional
+# Only needed when publishing as a Farcaster Mini App.
+# Consumed by src/app/.well-known/farcaster.json/route.ts and
+# src/app/layout.tsx.
+# ------------------------------------------------------------------
+
+# Canonical public URL of the deployed app (also used for layout metadata).
+NEXT_PUBLIC_URL=
+
+# Signed account association for the Farcaster manifest.
+FARCASTER_HEADER=
+FARCASTER_PAYLOAD=
+FARCASTER_SIGNATURE=
+
+# Mini App branding / metadata.
+NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME=
+NEXT_PUBLIC_APP_SUBTITLE=
+NEXT_PUBLIC_APP_DESCRIPTION=
+NEXT_PUBLIC_APP_ICON=
+NEXT_PUBLIC_APP_SPLASH_IMAGE=
+NEXT_PUBLIC_SPLASH_IMAGE=
+NEXT_PUBLIC_SPLASH_BACKGROUND_COLOR=
+NEXT_PUBLIC_NOTIFICATIONS_WEBHOOK=
+NEXT_PUBLIC_APP_PRIMARY_CATEGORY=
+NEXT_PUBLIC_APP_HERO_IMAGE=
+NEXT_PUBLIC_APP_TAGLINE=
+NEXT_PUBLIC_APP_OG_TITLE=
+NEXT_PUBLIC_APP_OG_DESCRIPTION=
+NEXT_PUBLIC_APP_OG_IMAGE=
+
+# ------------------------------------------------------------------
+# CRON / OPS — optional
+# Only needed when running scheduled jobs on Vercel.
+# ------------------------------------------------------------------
+
+# Shared secret that gates /api/cron/exchange-rates-update.
+# Vercel Cron sends this as a Bearer token in the Authorization header.
+CRON_SECRET=
+
+# ------------------------------------------------------------------
+# Test-only variables (e.g. PRIVATE_KEY for on-chain integration tests)
+# live in .env.test.example / .env.test.local instead of this file.
+# See TESTING.md for details.
+# ------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,19 @@ NEXT_PUBLIC_APP_OG_IMAGE=
 CRON_SECRET=
 
 # ------------------------------------------------------------------
+# OBSERVABILITY — optional
+# ------------------------------------------------------------------
+
+# Sentry DSN — https://sentry.io. Used by sentry.server.config.ts,
+# sentry.edge.config.ts, and instrumentation-client.ts. Exposed to the
+# browser bundle; the DSN is not a secret by Sentry's design.
+NEXT_PUBLIC_SENTRY_DSN=
+
+# Sentry auth token for source map uploads during build (not runtime).
+# Only needed in CI / production builds — leave blank for local dev.
+SENTRY_AUTH_TOKEN=
+
+# ------------------------------------------------------------------
 # Test-only variables (e.g. PRIVATE_KEY for on-chain integration tests)
 # live in .env.test.example / .env.test.local instead of this file.
 # See TESTING.md for details.

--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,20 @@
+# OneRamp Frontend — Test Environment Variables
+#
+# Copy this file to .env.test.local and fill in the values:
+#   cp .env.test.example .env.test.local
+#
+# Jest (via next/jest) loads .env.test.local and .env.test automatically
+# when NODE_ENV=test. .env.local is intentionally NOT loaded in test mode,
+# so test-only secrets belong here, not in .env.local.
+#
+# Only tests read these variables — no runtime code in src/ touches them.
+
+# ------------------------------------------------------------------
+# ON-CHAIN INTEGRATION TESTS
+# ------------------------------------------------------------------
+
+# Test wallet private key for __tests__/onchain-swaps.test.js.
+# This test signs real transactions against Base mainnet, so use a
+# disposable test wallet with minimal funds — NEVER a key that holds
+# real value or is shared with any other environment.
+PRIVATE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env*.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, copy the example env file and fill in the values:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
+cp .env.example .env.local
+```
+
+See `.env.example` for the list of required and optional variables.
+
+Then install dependencies and run the development server:
+
+```bash
+bun install
 bun dev
 ```
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -50,3 +50,31 @@ The tests provide comprehensive coverage for the cashout fees utility functions:
 - **Jest Configuration**: `jest.config.js`
 - **Setup File**: `jest.setup.js`
 - **TypeScript Support**: Configured in `tsconfig.json` with `"jest"` in types array
+
+## Environment Variables for Tests
+
+Jest is wired up through `next/jest`, which automatically loads Next.js env
+files when `NODE_ENV=test`. The load order is:
+
+1. `.env.test.local` — your personal test secrets, gitignored
+2. `.env.test` — committed test defaults (if any)
+3. `.env` — committed shared defaults
+
+`.env.local` is intentionally **not** loaded in test mode, so anything a test
+needs must live in one of the files above.
+
+To set up test-only variables, copy the template:
+
+```bash
+cp .env.test.example .env.test.local
+```
+
+Then fill in the values. `.env.test.example` lists every variable a test
+reads and describes what it's for.
+
+### On-chain integration tests
+
+`__tests__/onchain-swaps.test.js` signs real transactions against Base
+mainnet and requires `PRIVATE_KEY` to be set in `.env.test.local`. Use a
+disposable test wallet — never a key that holds real funds or is shared with
+any other environment.

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://1f11303be3c89c074231e991e2091838@o4510300602761216.ingest.us.sentry.io/4510300607086592",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://1f11303be3c89c074231e991e2091838@o4510300602761216.ingest.us.sentry.io/4510300607086592",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://1f11303be3c89c074231e991e2091838@o4510300602761216.ingest.us.sentry.io/4510300607086592",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,


### PR DESCRIPTION
## Summary

- Adds `.env.example` documenting every runtime env var the frontend reads, grouped by required vs optional (backend API, web3/wallet, Farcaster manifest, cron/ops)
- Adds a separate `.env.test.example` for test-only secrets so `PRIVATE_KEY` (used by `__tests__/onchain-swaps.test.js` to sign real Base mainnet txs) doesn't live alongside runtime config where it could get confused for an app-level credential
- Updates `.gitignore` with a `!.env*.example` exception so both templates are trackable
- Updates `README.md` and `TESTING.md` to point new contributors at the templates and explain the `next/jest` env load order

## Why a separate `.env.test.example`?

`next/jest` automatically loads `.env.test.local` → `.env.test` → `.env` when `NODE_ENV=test` and intentionally skips `.env.local`, so test-only secrets have a clean home that never bleeds into the runtime `.env.local`. Keeping `PRIVATE_KEY` out of `.env.example` also avoids tempting anyone to drop a real hot-wallet key into their local runtime config.

## Scope note

This PR is intentionally a documentation-only quick fix. The companion audit issue (#26) will determine whether any of these variables should be renamed, removed, or made required — if that audit changes the list, the templates should be updated to match.

## Test plan

- [ ] `cp .env.example .env.local`, fill in `ONERAMP_API_URL` + `ONERAMP_API_KEY`, run `bun dev`, and confirm the app boots against the backend
- [ ] Confirm `git check-ignore .env.example .env.test.example` reports them as matched by the `!.env*.example` exception (not ignored)
- [ ] Confirm `.env.local` and `.env.test.local` are still gitignored as expected
- [ ] `cp .env.test.example .env.test.local`, set `PRIVATE_KEY`, and run `bun test __tests__/onchain-swaps.test.js` to verify the test env loads via `next/jest`

Closes #25