### PR TITLE
chore(kyc): migrate to consolidated GET /kyc endpoint

### DIFF
--- a/src/actions/kyc.ts
+++ b/src/actions/kyc.ts
@@ -7,10 +7,23 @@ export const getKYC = async (address: string) => {
       return null;
     }
 
-    const response = await oneRampApi.get(`/kyc/${address}`);
+    const response = await oneRampApi.get(`/kyc`, {
+      params: { address },
+    });
 
     return response.data;
   } catch (error) {
+    // 404 = no KYC record bound to this address yet — surface as null,
+    // not as a thrown error. The api migrated to a canonical 404 shape
+    // for misses; the frontend treats "no record" as an empty state.
+    if (
+      error &&
+      typeof error === "object" &&
+      "response" in error &&
+      (error as { response?: { status?: number } }).response?.status === 404
+    ) {
+      return null;
+    }
     throw new Error("Failed to get KYC", { cause: error });
   }
 };

--- a/src/app/buy-interface/buy-interface.tsx
+++ b/src/app/buy-interface/buy-interface.tsx
@@ -337,7 +337,7 @@ export function BuyInterface() {
 
   // Handle KYC completion and auto-retry buy
   // useEffect(() => {
-  //   if (kycTriggered && kycData && kycData.kycStatus === "VERIFIED") {
+  //   if (kycTriggered && kycData && kycData.status === "VERIFIED") {
   //     setKycTriggered(false);
   //     setShowKYCModal(false);
   //     // Auto-retry the buy flow after KYC completion

--- a/src/app/pay-interface/pay-interface.tsx
+++ b/src/app/pay-interface/pay-interface.tsx
@@ -487,7 +487,7 @@ export function PaymentInterface() {
 
   // Handle KYC completion and auto-retry payment
   // useEffect(() => {
-  //   if (kycTriggered && kycData && kycData.kycStatus === "VERIFIED") {
+  //   if (kycTriggered && kycData && kycData.status === "VERIFIED") {
   //     setKycTriggered(false);
   //     setShowKYCModal(false);
   //     // Auto-retry the payment after KYC completion

--- a/src/app/withdraw-interface/cNGN/CNGNWithdrawPanel.tsx
+++ b/src/app/withdraw-interface/cNGN/CNGNWithdrawPanel.tsx
@@ -620,7 +620,7 @@ export default function CNGNWithdrawPanel() {
 
   const handleConnectWallet = () => setShowWalletModal(true);
   const handleStartKYC = () => {
-    if (kycData && kycData.kycStatus !== "VERIFIED") {
+    if (kycData && kycData.status !== "VERIFIED") {
       setShowKYCModal(true);
       toast.error("KYC verification required");
       return;

--- a/src/app/withdraw-interface/withdraw-interface.tsx
+++ b/src/app/withdraw-interface/withdraw-interface.tsx
@@ -670,14 +670,14 @@ export function WithdrawInterface({
   // Handle KYC start
   const handleStartKYC = () => {
     // Check KYC status and show modal
-    if (kycData && kycData.kycStatus !== "VERIFIED") {
+    if (kycData && kycData.status !== "VERIFIED") {
       setShowKYCModal(true);
       toast.error("KYC verification required");
       return;
     }
 
     // If somehow KYC is already verified, proceed with withdrawal
-    if (kycData?.kycStatus === "VERIFIED") {
+    if (kycData?.status === "VERIFIED") {
       console.log("KYC already verified, proceeding...");
     }
   };

--- a/src/components/modals/KYCVerificationModal.tsx
+++ b/src/components/modals/KYCVerificationModal.tsx
@@ -31,7 +31,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
   const { data: kycData } = useKYCStatusSuspense({ address: address || "" });
 
   useEffect(() => {
-    if (kycData && kycData.kycStatus === "VERIFIED") {
+    if (kycData && kycData.status === "VERIFIED") {
       setShowKYCModal(false);
       setIsCheckingKyc(false);
     }
@@ -178,7 +178,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
             </div>
           </div>
 
-          <div className="">{JSON.stringify(kycData?.kycStatus, null, 2)}</div>
+          <div className="">{JSON.stringify(kycData?.status, null, 2)}</div>
 
           <div className="mt-6 bg-[#232323] rounded-xl p-4">
             <h3 className="text-white font-medium mb-4">
@@ -297,7 +297,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
   }
 
   // Prevent new KYC submission if user has REJECTED or IN_REVIEW status
-  if (kycData?.kycStatus === "REJECTED" || kycData?.kycStatus === "IN_REVIEW") {
+  if (kycData?.status === "REJECTED" || kycData?.status === "IN_REVIEW") {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#1c1c1c] md:bg-black/60 md:backdrop-blur-lg">
         <div
@@ -325,7 +325,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
               KYC Already in Progress
             </h2>
             <p className="text-neutral-400 text-sm mb-6">
-              {kycData?.kycStatus === "REJECTED"
+              {kycData?.status === "REJECTED"
                 ? "Your previous KYC verification was rejected. Please wait for the review process to complete before submitting a new verification."
                 : "Your KYC verification is currently under review. Please wait for the review process to complete before submitting a new verification."}
             </p>
@@ -337,7 +337,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
                     <div className="w-2 h-2 bg-orange-400 rounded-full"></div>
                   </div>
                   <p className="text-neutral-400 text-sm">
-                    {kycData?.kycStatus === "REJECTED"
+                    {kycData?.status === "REJECTED"
                       ? "Your verification was not approved and is being reviewed"
                       : "Your verification is being reviewed by our team"}
                   </p>
@@ -368,7 +368,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
   }
 
   // Show KYC status based on current status
-  if (kycData?.kycStatus === "REJECTED") {
+  if (kycData?.status === "REJECTED") {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#1c1c1c] md:bg-black/60 md:backdrop-blur-lg">
         <div
@@ -456,7 +456,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
   }
 
   // Show IN_REVIEW KYC status
-  if (kycData?.kycStatus === "IN_REVIEW") {
+  if (kycData?.status === "IN_REVIEW") {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#1c1c1c] md:bg-black/60 md:backdrop-blur-lg">
         <div
@@ -543,7 +543,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
   }
 
   // Show pending KYC status
-  if (kycData?.kycStatus === "PENDING") {
+  if (kycData?.status === "PENDING") {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#1c1c1c] md:bg-black/60 md:backdrop-blur-lg">
         <div
@@ -664,7 +664,7 @@ export function KYCVerificationModal({ open }: KYCVerificationModalProps) {
   }
 
   // Show successful KYC status
-  if (kycData?.kycStatus === "VERIFIED") {
+  if (kycData?.status === "VERIFIED") {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-[#1c1c1c] md:bg-black/60 md:backdrop-blur-lg">
         <div

--- a/src/components/modals/TransactionReviewModal.tsx
+++ b/src/components/modals/TransactionReviewModal.tsx
@@ -252,15 +252,15 @@ export function TransactionReviewModal() {
     if (!quote) return;
 
     // Verify KYC status before proceeding
-    if (kycData && kycData.kycStatus !== "VERIFIED") {
+    if (kycData && kycData.status !== "VERIFIED") {
       console.error("KYC verification required");
       return;
     }
 
     // Additional check for rejected or in-review KYC
     if (
-      kycData?.kycStatus === "REJECTED" ||
-      kycData?.kycStatus === "IN_REVIEW"
+      kycData?.status === "REJECTED" ||
+      kycData?.status === "IN_REVIEW"
     ) {
       console.error("KYC verification is not complete");
       return;

--- a/src/components/select-institution.tsx
+++ b/src/components/select-institution.tsx
@@ -600,14 +600,14 @@ const SelectInstitution = ({
 
     if (!allowKycBypassForMomo) {
       // Default KYC gates
-      if (kycData && kycData.kycStatus !== "VERIFIED") {
+      if (kycData && kycData.status !== "VERIFIED") {
         toast.error("KYC verification required");
         return;
       }
 
       if (
-        kycData?.kycStatus === "REJECTED" ||
-        kycData?.kycStatus === "IN_REVIEW"
+        kycData?.status === "REJECTED" ||
+        kycData?.status === "IN_REVIEW"
       ) {
         toast.error(
           "KYC verification is not complete. Please wait for verification to finish."

--- a/src/hooks/useKYCStatus.tsx
+++ b/src/hooks/useKYCStatus.tsx
@@ -55,14 +55,14 @@ export const useKYCStatus = () => {
           try {
             const response = await getKYC(address);
             if (response) {
-              console.log("KYC status update:", response.kycStatus);
+              console.log("KYC status update:", response.status);
               setKycData(response);
 
               // Stop polling if verification is complete (VERIFIED, REJECTED, or IN_REVIEW)
               if (
-                response.kycStatus === "VERIFIED" ||
-                response.kycStatus === "REJECTED" ||
-                response.kycStatus === "IN_REVIEW"
+                response.status === "VERIFIED" ||
+                response.status === "REJECTED" ||
+                response.status === "IN_REVIEW"
               ) {
                 console.log("KYC verification complete, stopping polling");
                 cleanupPolling();
@@ -100,9 +100,9 @@ export const useKYCStatus = () => {
 
         // If verification is complete, stop polling
         if (
-          response.kycStatus === "VERIFIED" ||
-          response.kycStatus === "REJECTED" ||
-          response.kycStatus === "IN_REVIEW"
+          response.status === "VERIFIED" ||
+          response.status === "REJECTED" ||
+          response.status === "IN_REVIEW"
         ) {
           cleanupPolling();
         }

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -219,11 +219,17 @@ export const appRouter = createTRPCRouter({
       }
 
       try {
-        const response = await oneRampApi.get(`/kyc/${address}`);
+        const response = await oneRampApi.get(`/kyc`, {
+          params: { address },
+        });
         return response.data;
       } catch (error) {
-        console.error("Error fetching KYC:", error);
-        // throw new Error("Failed to fetch KYC");
+        // 404 = no KYC record bound; treat as empty state.
+        const status = (error as { response?: { status?: number } })?.response
+          ?.status;
+        if (status !== 404) {
+          console.error("Error fetching KYC:", error);
+        }
         return null;
       }
     }),

--- a/src/utils/kyc-verification.ts
+++ b/src/utils/kyc-verification.ts
@@ -54,7 +54,7 @@ export interface KYCVerificationOptions {
    * KYC data from the store/API
    */
   kycData?: {
-    kycStatus?: string;
+    status?: string;
     [key: string]: unknown;
   } | null;
 
@@ -174,7 +174,7 @@ export function verifyKYC(
   }
 
   // Check KYC status (handle both string and typed values)
-  const kycStatus = kycData.kycStatus?.toString().toUpperCase();
+  const kycStatus = kycData.status?.toString().toUpperCase();
 
   // If verified, proceed
   if (kycStatus === "VERIFIED") {

--- a/types.ts
+++ b/types.ts
@@ -238,10 +238,25 @@ export interface ExchangeRateResponse {
 
 // Institution interface of type key value pair
 
+/**
+ * Response from `GET /kyc?address=…` (and `?email=…` / `?phone_number=…`).
+ *
+ * `id`, `status`, `createdAt` are the canonical fields from the
+ * consolidated endpoint. `addressKYC` and `fullKYC` carry PII used by
+ * withdraw/buy auto-fill UX — the api retains them for now; a future
+ * authorized "/kyc/:id/details" split could move PII behind a stronger
+ * gate, but until that exists the frontend depends on these fields
+ * being present.
+ *
+ * `status` is typed as `string` (not the enum) to keep the compile-time
+ * surface compatible with the legacy code that compared loosely.
+ */
 export interface KYCVerificationResponse {
+  id: string;
+  status: string;
+  createdAt: string;
   error?: string;
-  kycStatus: string;
-  message: {
+  message?: {
     link: string;
   };
   addressKYC: {


### PR DESCRIPTION
Closes #33.

## Summary
- Switch the two KYC API call sites from path-param `GET /kyc/:address` to query-param `GET /kyc?address=…` (api consolidation per [oneramp-api-backend#119](https://github.com/ViFiLabs/oneramp-api-backend/pull/119)).
- Rename `kycStatus` → `status` across ~22 consumer sites; same enum (`PENDING | IN_REVIEW | VERIFIED | REJECTED`).
- Treat api 404 as the empty state (returns null) instead of throwing.
- Update `KYCVerificationResponse` to add `id` + `createdAt`; PII blocks (`addressKYC`, `fullKYC`) retained — withdraw/buy auto-fill depends on them.

## Coordination

⚠️ **Don't merge before [oneramp-api-backend#119](https://github.com/ViFiLabs/oneramp-api-backend/pull/119) ships.** The new endpoint shape doesn't exist on prod yet; this PR will 404 against the current api until #119 deploys.

## Test plan
- [ ] `bunx tsc --noEmit` passes (verified locally — only pre-existing `__tests__/cashout-fees.test.ts` errors remain, unrelated to this PR).
- [ ] Smoke: connect wallet with a verified KYC, observe `useKYCStatus` polling resolves to `status === "VERIFIED"`.
- [ ] Smoke: connect wallet with no KYC binding, observe 404 → `kycData` stays null, `KYCVerificationModal` opens to start KYC.
- [ ] Smoke: withdraw flow auto-fills name/phone/document from `fullKYC` (api still returns these fields).